### PR TITLE
move devDependencies to dependencies so heroku will install needed pa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "watch": "webpack -d --watch",
     "babel": "babel server/src/ -d server/dist",
     "babel-w": "babel-watch server/src/index.js",
-    "prestart": "npm install && npm run lint && npm run build",
+    "prestart": "npm install && npm run build",
     "build": "npm run babel && npm run webpack",
     "lint": "eslint 'server/**/*.js ';",
     "dev": "export NODE_ENV=development && npm run lint && npm run babel && concurrently --kill-others --raw \"npm run nodemon\" \"npm run watch\" "
@@ -26,24 +26,22 @@
     "url": "https://github.com/polarbasin/polarbasin/issues"
   },
   "homepage": "https://github.com/polarbasin/polarbasin#readme",
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "^6.11.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-watch": "^2.0.2",
+    "dotenv": "^2.0.0",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.0.0",
-    "html-loader": "^0.4.3",
-    "webpack": "^1.13.1"
-  },
-  "dependencies": {
-    "dotenv": "^2.0.0",
     "express": "^4.14.0",
+    "html-loader": "^0.4.3",
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "webpack": "^1.13.1"
   }
 }


### PR DESCRIPTION
The babel packages were incorrectly in the `devDependencies` list so Heroku wasn't installing them and therefore not building the app. I moved everything to `dependencies`. Should be okay now.
