### PR TITLE
(fix) use negative heading on compass for correct orientation

### DIFF
--- a/client/app/components/Compass.jsx
+++ b/client/app/components/Compass.jsx
@@ -12,7 +12,7 @@ const cardLabels = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
 
 const Compass = ({ compassHeading, origin, dest }) => (
   <div>
-    <div id="compass" style={{ transform: `rotateZ(${compassHeading}deg)` }} >
+    <div id="compass" style={{ transform: `rotateZ(-${compassHeading}deg)` }} >
       <div id="spinner" style={{ transition: 'none' }}>
         <div id="pin" />
         {


### PR DESCRIPTION
Fix wonky compass movement by inverting compass heading.
